### PR TITLE
chore: bump gson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <arguments />
         <version.jackson>2.17.2</version.jackson>
         <version.logback>1.5.18</version.logback>
-        <version.gson>2.11.0</version.gson>
+        <version.gson>2.13.2</version.gson>
     </properties>
 
     <name>io.getunleash:unleash-client-java</name>


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
Bump gson from `2.11.0` to `2.13.2`

Context for the change: gson in `2.11.0` was tagged as security vulnerability by Sonatype. 
